### PR TITLE
Send simple values besides the json package to MQTT.

### DIFF
--- a/homesensorhub/routing/mqtt_sender.py
+++ b/homesensorhub/routing/mqtt_sender.py
@@ -80,13 +80,7 @@ class MQTTDataSender(DataSender):
 
         sensors-office/temperature/current/value 27.68
         """
-        payload_attributes = {
-            'type': payload.get_str_type(),
-            'name': payload.get_str_name(),
-            'value': payload.get_str_value(),
-            'timestamp': payload.get_str_timestamp(),
-            'measurement': payload.get_str_measurement()
-        }
+        payload_attributes = payload.get_string_payload()
 
         for attribute, collected in payload_attributes.items():
             type = payload.get_str_type()

--- a/homesensorhub/routing/payload.py
+++ b/homesensorhub/routing/payload.py
@@ -22,11 +22,11 @@ class Payload:
         needs to be refined into an accepted form.
         """
         payload = {
-            'type': self.__get_str_type(),
-            'name': self.__get_str_name(),
-            'value': self.__get_str_value(),
-            'timestamp': self.__get_str_timestamp(),
-            'measurement': self.__get_str_measurement()
+            'type': self.get_str_type(),
+            'name': self.get_str_name(),
+            'value': self.get_str_value(),
+            'timestamp': self.get_str_timestamp(),
+            'measurement': self.get_str_measurement()
         }
 
         json_payload = json.dumps(payload,
@@ -35,29 +35,26 @@ class Payload:
                                   sort_keys=True)
         return json_payload
 
-    def __get_str_type(self) -> str:
-        return str(self.__type)
-
-    def __get_str_name(self) -> str:
-        return str(self.__name)
-
-    def __get_str_value(self) -> str:
-        return "{}".format(round(self.__value, 2))
-
-    def __get_str_timestamp(self) -> str:
-        return str(self.__timestamp)
-
-    def __get_str_measurement(self) -> str:
-        return str(self.__measurement)
-
-    def get_value(self):
-        """Return the value of the sensor."""
-        return self.__value
-
-    def get_type(self):
+    def get_str_type(self) -> str:
         """
-        Return the type of the sensor.
+        Return the type of the sensor in string format.
 
         Needed for topic creation in MQTT.
         """
-        return self.__type
+        return str(self.__type)
+
+    def get_str_name(self) -> str:
+        """Return the name of the sensor in string format."""
+        return str(self.__name)
+
+    def get_str_value(self) -> str:
+        """Return the value collected by the sensor in string format."""
+        return "{}".format(round(self.__value, 2))
+
+    def get_str_timestamp(self) -> str:
+        """Return the timestamp of the value extraction in string format."""
+        return str(self.__timestamp)
+
+    def get_str_measurement(self) -> str:
+        """Return the unit of measurement for the value in string format."""
+        return str(self.__measurement)

--- a/homesensorhub/routing/payload.py
+++ b/homesensorhub/routing/payload.py
@@ -6,12 +6,21 @@ class Payload:
     """Class which implements the configuration of the payload for MQTT."""
 
     def __init__(self, type, name, value, timestamp, measurement):
-        """Extract and structure the data received from the sensors."""
+        """Structure the data received from the sensors."""
         self.__type = type
         self.__name = name
         self.__value = value
         self.__timestamp = timestamp
         self.__measurement = measurement
+
+    def get_string_payload(self) -> dict:
+        """Return the payload of collected data for a sensor type."""
+        payload = {'type': self.get_str_type(),
+                   'name': self.get_str_name(),
+                   'value': self.get_str_value(),
+                   'timestamp': self.get_str_timestamp(),
+                   'measurement': self.get_str_measurement()}
+        return payload
 
     def get_json_payload(self) -> json.dumps:
         """
@@ -21,18 +30,8 @@ class Payload:
         before trying to send the raw data from the sensors through MQTT, it
         needs to be refined into an accepted form.
         """
-        payload = {
-            'type': self.get_str_type(),
-            'name': self.get_str_name(),
-            'value': self.get_str_value(),
-            'timestamp': self.get_str_timestamp(),
-            'measurement': self.get_str_measurement()
-        }
-
-        json_payload = json.dumps(payload,
-                                  indent=4,
-                                  separators=(". ", " = "),
-                                  sort_keys=True)
+        json_payload = json.dumps(self.get_string_payload(),
+                                  indent=4)
         return json_payload
 
     def get_str_type(self) -> str:

--- a/tests/sensors/test_light_sensors.py
+++ b/tests/sensors/test_light_sensors.py
@@ -32,9 +32,9 @@ class TestLightSensors(unittest.TestCase):
 
                 collected_data = sensor.get_data()
                 payload = collected_data[0]
-                actual_data = payload.get_value()
+                actual_data = payload.get_str_value()
 
-                self.assertEquals(actual_data, ls.read.return_value)
+                self.assertEquals(actual_data, str(ls.read.return_value))
 
             time.sleep(0.1)
 


### PR DESCRIPTION
Fixes #18.

Instead of sending the whole json payload (which will be usefull for database collection), also send each value as a separate publish (which is useful for haas). The result for one type of sensor is the following:

sensors-office/temperature/current {
    "measurement" = "celsius". 
    "name" = "<class 'adafruit_bme280.Adafruit_BME280_I2C'>". 
    "timestamp" = "2020-08-07 18:12:10.044375". 
    "type" = "temperature". 
    "value" = "27.48"
}
sensors-office/temperature/current/type temperature
sensors-office/temperature/current/name <class 'adafruit_bme280.Adafruit_BME280_I2C'>
sensors-office/temperature/current/value 27.48
sensors-office/temperature/current/timestamp 2020-08-07 18:12:10.044375
sensors-office/temperature/current/measurement celsius