### PR TITLE
Mqtt config

### DIFF
--- a/homesensorhub/__main__.py
+++ b/homesensorhub/__main__.py
@@ -30,13 +30,9 @@ for function in probefunctions:
 
 # after the MQTT connection has been established and the sensors probed, the subscribe topics can
 # be built based on the sensors properties
-def set_mqtt_subscribers():
-    mqtt_subscriber.set_sensors(sensor_types)
-    mqtt_subscriber.set_sensors_subscribe_topics()
-    mqtt_subscriber.subscribe()
 
 
-set_mqtt_subscribers()
+mqtt_subscriber.subscribe_to_sensor_properties(sensor_types)
 
 
 sensor_sink = SourceAndSink(sensor_types, sender)

--- a/homesensorhub/__main__.py
+++ b/homesensorhub/__main__.py
@@ -31,7 +31,8 @@ for function in probefunctions:
 # after the MQTT connection has been established and the sensors probed, the subscribe topics can
 # be built based on the sensors properties
 def set_mqtt_subscribers():
-    mqtt_subscriber.set_sensors_subscribe_topics(sensor_types)
+    mqtt_subscriber.set_sensors(sensor_types)
+    mqtt_subscriber.set_sensors_subscribe_topics()
     mqtt_subscriber.subscribe()
 
 

--- a/homesensorhub/routing/mqtt.py
+++ b/homesensorhub/routing/mqtt.py
@@ -26,7 +26,6 @@ class MQTT(metaclass=Singleton):
 
     def __init__(self, broker_url="mqtt.tinker.haus", broker_port=1883):
         self.__client = mqtt.Client()
-        self.__client.on_message = self.on_message
         self.__client.on_connect = self.on_connect
 
         self.__broker_url = broker_url
@@ -50,9 +49,6 @@ class MQTT(metaclass=Singleton):
         except ConnectionRefusedError as error:
             logging.error("MQTT connect refused: {}".format(error))
             return False
-
-    def on_message(self, client, userdata, message):
-        print("{}; {}; {}.".format(client, userdata, message))
 
     def on_connect(self, client, userdata, flags, rc):
         logging.info("Succesfully connected to {}".format(self.__broker_url))

--- a/homesensorhub/routing/mqtt.py
+++ b/homesensorhub/routing/mqtt.py
@@ -27,6 +27,7 @@ class MQTT(metaclass=Singleton):
     def __init__(self, broker_url="mqtt.tinker.haus", broker_port=1883):
         self.__client = mqtt.Client()
         self.__client.on_connect = self.on_connect
+        self.__client.on_log = self.on_log
 
         self.__broker_url = broker_url
         self.__broker_port = broker_port
@@ -50,8 +51,23 @@ class MQTT(metaclass=Singleton):
             logging.error("MQTT connect refused: {}".format(error))
             return False
 
+    def set_message_callback(self, callback):
+        self.__client.on_message = callback
+
+    def subscribe(self, topics):
+        """Stop the mqtt subscribe loop to add the sensors properties subscribe topics."""
+        self.__client.loop_stop()
+
+        logging.info("Setting MQTT subscribers.")
+        self.__client.subscribe(topics)
+
+        self.__client.loop_start()
+
     def on_connect(self, client, userdata, flags, rc):
         logging.info("Succesfully connected to {}".format(self.__broker_url))
+
+    def on_log(self, mqttc, obj, level, string):
+        logging.debug(string)
 
     def get_topic_base(self):
         """Return topic base used for publish."""

--- a/homesensorhub/routing/mqtt_sender.py
+++ b/homesensorhub/routing/mqtt_sender.py
@@ -3,8 +3,6 @@ from routing.data_sender import DataSender
 from routing.mqtt import MQTT
 
 import logging
-import paho.mqtt.client as mqtt
-import time
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -47,11 +45,11 @@ class MQTTSender(DataSender):
         }
         """
         json_payload = payload.get_json_payload()
-        type = payload.get_str_type() + "/"
+        type = "/" + payload.get_str_type()
         topic_base = self.__mqtt.get_topic_base()
-        topic = "{}{}current".format(topic_base, type)
+        topic = "{}{}".format(topic_base, type)
 
-        self.__publish(topic, json_payload)
+        self.__mqtt.publish(topic, json_payload)
 
     def __send_simple_values(self, payload):
         """
@@ -65,23 +63,9 @@ class MQTTSender(DataSender):
         payload_attributes = payload.get_string_payload()
 
         for attribute, collected in payload_attributes.items():
-            type = payload.get_str_type() + "/"
+            type = "/" + payload.get_str_type()
+            attribute = "/" + attribute
             topic_base = self.__mqtt.get_topic_base()
-            topic = "{}{}current/{}".format(topic_base, type, attribute)
+            topic = "{}{}{}".format(topic_base, type, attribute)
 
-            self.__publish(topic, collected)
-
-    def __publish(self, topic, payload):
-        result = (mqtt.MQTT_ERR_AGAIN, 0)
-
-        while result[0] != mqtt.MQTT_ERR_SUCCESS:
-            mqtt_client = self.__mqtt.get_client()
-            result = mqtt_client.publish(topic=topic,
-                                         payload=payload,
-                                         qos=0,
-                                         retain=False)
-
-            if(result[0] == mqtt.MQTT_ERR_NO_CONN):
-                logging.warn("MQTT bus unresponsive, reconnecting...")
-                self.__mqtt.connect()
-                time.sleep(1)
+            self.__mqtt.publish(topic, collected)

--- a/homesensorhub/routing/mqtt_subscriber.py
+++ b/homesensorhub/routing/mqtt_subscriber.py
@@ -15,15 +15,25 @@ class MQTTSubscriber():
     def __init__(self, broker_url="mqtt.tinker.haus", broker_port=1883):
         self.__mqtt = MQTT(broker_url, broker_port)
         self.__topics = []
+        self.__mqtt.get_client().on_message = self.on_message
+        self.__sensors = None
 
-    def set_sensors_subscribe_topics(self, sensors: list):
+    def set_sensors(self, sensors):
+        """Set sensors for topic set and message callbacks."""
+        self.__sensors = sensors
+
+    def on_message(self, client, userdata, message):
+        print("{};".format(dir(message)))
+
+    def set_sensors_subscribe_topics(self):
         """Extract type and propetries from each sensor and build their subscribe topics."""
-        for sensor in sensors:
+        for sensor in self.__sensors:
             type = sensor.get_type()
-            self.set_sensor_subscribe_topic(type=type, sensor_properties=sensor.get_properties())
+            self.__set_sensor_subscribe_topic(type=type, sensor_properties=sensor.get_properties())
+
         print("Generated topics: {}".format(self.__topics))
 
-    def set_sensor_subscribe_topic(self, type, sensor_properties):
+    def __set_sensor_subscribe_topic(self, type, sensor_properties):
         """
         Build a sensor's subscribe topic based on its properties and type.
 

--- a/homesensorhub/routing/mqtt_subscriber.py
+++ b/homesensorhub/routing/mqtt_subscriber.py
@@ -29,6 +29,7 @@ class MQTTSubscriber():
 
     def on_message(self, client, userdata, message):
         """Read message and set property based on the type and payload."""
+        # print("Topic {}.\n Payload {}".format(message.topic, message.payload))
         type, property = self.get_type_and_property(message.topic)
 
         for sensor in self.__sensors:
@@ -47,8 +48,8 @@ class MQTTSubscriber():
         """Split the topic to extract the type and property."""
         baseless_topic = topic.replace(self.__mqtt.get_topic_base(), '')
         split_topic = baseless_topic.split(sep='/')
-        type = split_topic[0]
-        property = split_topic[1]
+        type = split_topic[1]
+        property = split_topic[2]
 
         return type, property
 
@@ -73,6 +74,7 @@ class MQTTSubscriber():
         /user/hostname/sensor_type/property 10
         """
         for property in sensor_properties.keys():
-            type_topic = type + "/"
-            topic = "{}{}{}".format(self.__mqtt.get_topic_base(), type_topic, property)
+            type_topic =  "/" + type
+            property_topic = "/" + property
+            topic = "{}{}{}".format(self.__mqtt.get_topic_base(), type_topic, property_topic)
             self.__topics.append((topic, self.__mqtt.get_qos()))

--- a/homesensorhub/routing/mqtt_subscriber.py
+++ b/homesensorhub/routing/mqtt_subscriber.py
@@ -19,6 +19,11 @@ class MQTTSubscriber():
         self.__mqtt.get_client().on_log = self.on_log
         self.__sensors = None
 
+    def subscribe_to_sensor_properties(self, sensors):
+        self.set_sensors(sensors)
+        self.set_sensors_subscribe_topics()
+        self.subscribe()
+
     def set_sensors(self, sensors):
         """Set sensors for topic set and message callbacks."""
         self.__sensors = sensors

--- a/homesensorhub/sensors/sensor_types.py
+++ b/homesensorhub/sensors/sensor_types.py
@@ -35,8 +35,14 @@ class SensorTypePolled(SensorType):
         }
 
     def set_pollrate(self, pollrate):
-        print("Setting pollrate to {}".format(pollrate))
-        self.__pollrate = pollrate
+        pollrate = pollrate.decode('utf-8')
+        try:
+            pollrate = int(pollrate)
+            self.__pollrate = pollrate
+            print("Set the pollrate to {}".format(self.__pollrate))
+        except ValueError:
+            print("Cannot convert pollrate to integer. The value is not an integer.")
+            return
 
     def get_pollrate(self):
         return self.__pollrate

--- a/homesensorhub/sensors/sensor_types.py
+++ b/homesensorhub/sensors/sensor_types.py
@@ -39,7 +39,7 @@ class SensorTypePolled(SensorType):
         try:
             pollrate = int(pollrate)
             self.__pollrate = pollrate
-            print("Set the pollrate to {}".format(self.__pollrate))
+            print("Set the pollrate to the {} sensor to {}".format(self.TYPE, self.__pollrate))
         except ValueError:
             print("Cannot convert pollrate to integer. The value is not an integer.")
             return

--- a/homesensorhub/sensors/sensor_types.py
+++ b/homesensorhub/sensors/sensor_types.py
@@ -35,6 +35,7 @@ class SensorTypePolled(SensorType):
         }
 
     def set_pollrate(self, pollrate):
+        print("Setting pollrate to {}".format(pollrate))
         self.__pollrate = pollrate
 
     def get_pollrate(self):
@@ -80,11 +81,5 @@ class CallbackPair:
     """Create a setter getter object type for access to sensor properties."""
 
     def __init__(self, setter, getter):
-        self.__setter = setter
-        self.__getter = getter
-
-    def get_setter(self):
-        return self.__setter
-
-    def get_getter(self):
-        return self.__getter
+        self.setter = setter
+        self.getter = getter

--- a/homesensorhub/sensors/sensor_types.py
+++ b/homesensorhub/sensors/sensor_types.py
@@ -26,12 +26,19 @@ class SensorTypePolled(SensorType):
     """Type of sensor which is polled."""
 
     def __init__(self, pollrate=3):
-        self.pollrate = pollrate
+        self.__pollrate = pollrate
 
     def get_properties(self):
         return {
-            'pollrate': self.pollrate
+            'pollrate': CallbackPair(self.set_pollrate,
+                                     self.get_pollrate)
         }
+
+    def set_pollrate(self, pollrate):
+        self.__pollrate = pollrate
+
+    def get_pollrate(self):
+        return self.__pollrate
 
 
 class SensorTypeAsynchronous(SensorType):
@@ -67,3 +74,17 @@ class Temperature(SensorTypePolled):
 
 class Motion(SensorTypeAsynchronous):
     TYPE = 'motion'
+
+
+class CallbackPair:
+    """Create a setter getter object type for access to sensor properties."""
+
+    def __init__(self, setter, getter):
+        self.__setter = setter
+        self.__getter = getter
+
+    def get_setter(self):
+        return self.__setter
+
+    def get_getter(self):
+        return self.__getter


### PR DESCRIPTION
Fix #36 
Based on this, we can set the properties of any sensor by publishing a message of the following type on mqtt:

```python
% mosquitto_pub -h mqtt.tinker.haus -t "$USER/hostname/type/property" -m 1
```
As an example, the following will set the pollrate for the sensor temperature to 1 second:
```python
% mosquitto_pub -h mqtt.tinker.haus -t "$USER/hostname/temperature/pollrate -m 1
```
