### PR TITLE
Moved main functionality to homesensorhub.

### DIFF
--- a/homesensorhub/__main__.py
+++ b/homesensorhub/__main__.py
@@ -1,42 +1,5 @@
-"""Entry point for the application."""
-from routing.sensor_sink import SourceAndSink
-from routing.mqtt_sender import MQTTSender
-from routing.mqtt_subscriber import MQTTSubscriber
-
-from sensors.BoschBME280.probe import ProbeBoschBME280
-from sensors.BoschBME680.probe import ProbeBoschBME680
-from sensors.TSL258x.probe import ProbeTSL258x
-from sensors.RCWL0515.probe import ProbeRCWL0515
-
-mqtt_subscriber = MQTTSubscriber()
-mds = MQTTSender()
-sender = [mds]
-
-probefunctions = []
-probefunctions.append(ProbeBoschBME280.probe)
-probefunctions.append(ProbeBoschBME680.probe)
-probefunctions.append(ProbeTSL258x.probe)
-probefunctions.append(ProbeRCWL0515.probe)
-
-sensor_types = []
-
-for function in probefunctions:
-    sensor_list = function(mds.send_payload)  # TODO: Send a more generic data sender callback.
-    try:
-        sensor_types += sensor_list
-    except TypeError:
-        pass
+from homesensorhub import HomeSensorHub
 
 
-# after the MQTT connection has been established and the sensors probed, the subscribe topics can
-# be built based on the sensors properties
-
-
-mqtt_subscriber.subscribe_to_sensor_properties(sensor_types)
-
-
-sensor_sink = SourceAndSink(sensor_types, sender)
-sensor_sink.sink_and_send(3)
-
-for sensor in sensor_types:
-    sensor.stop()
+homesensorhub = HomeSensorHub()
+homesensorhub.run()

--- a/homesensorhub/homesensorhub.py
+++ b/homesensorhub/homesensorhub.py
@@ -1,0 +1,54 @@
+"""Entry point for the application."""
+from routing.sensor_sink import SourceAndSink
+from routing.mqtt_sender import MQTTSender
+from routing.mqtt_subscriber import MQTTSubscriber
+
+from sensors.BoschBME280.probe import ProbeBoschBME280
+from sensors.BoschBME680.probe import ProbeBoschBME680
+from sensors.TSL258x.probe import ProbeTSL258x
+from sensors.RCWL0515.probe import ProbeRCWL0515
+
+
+class HomeSensorHub:
+    def __init__(self):
+        self.__mqtt_subscriber = MQTTSubscriber()
+
+        probe_functions = self.find_probe_functions()
+        self.__senders = self.find_senders()
+        self.__sensors = self.find_sensors(probe_functions)
+
+        self.__mqtt_subscriber.subscribe_to_sensor_properties(self.__sensors)
+
+    def run(self):
+        sensor_sink = SourceAndSink(self.__sensors, self.__senders)
+        sensor_sink.sink_and_send()
+
+    def find_probe_functions(self):
+        probe_functions = []
+
+        probe_functions.append(ProbeBoschBME280.probe)
+        probe_functions.append(ProbeBoschBME680.probe)
+        probe_functions.append(ProbeTSL258x.probe)
+        probe_functions.append(ProbeRCWL0515.probe)
+
+        return probe_functions
+
+    def find_senders(self):
+        senders = []
+
+        senders.append(MQTTSender())
+
+        return senders
+
+    def find_sensors(self, probe_functions):
+        sensors = []
+        mqtt_sender = self.__senders[0]
+
+        for function in probe_functions:
+            sensor_list = function(mqtt_sender.send_payload)  # TODO: Send a generic sender callback. # noqa
+            try:
+                sensors += sensor_list
+            except TypeError:
+                pass
+
+        return sensors

--- a/homesensorhub/routing/sensor_sink.py
+++ b/homesensorhub/routing/sensor_sink.py
@@ -35,7 +35,7 @@ class SourceAndSink:
 
         return collected
 
-    def sink_and_send(self, interval: int) -> None:
+    def sink_and_send(self) -> None:
         """Sink all data from the sensors and send at a specified time interval."""
         logging.info("Sinking and sending data...")
 


### PR DESCRIPTION
The entrypoint of the application still remains the  __main__.py class, but I have created a HomeSensorHub class which has a run function to set up everything needed for the application. Main will only initialise the HomeSensorHub object and call its run function instead of having the logic of this object, but cluttered as it was before.